### PR TITLE
OAuth API remove

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
     "tests-prepare-s3": "php ./tests/loadToS3.php",
     "phplint": "parallel-lint -j 10 --exclude vendor .",
     "phpcs": "phpcs -n --ignore=vendor --extensions=php .",
+    "phpcbf": "phpcbf -n --ignore=vendor --extensions=php .",
     "phpstan": "phpstan analyse ./src ./tests --level=max --no-progress -c phpstan.neon",
     "tests": [
       "@composer validate --no-check-publish --no-check-all",

--- a/src/S3Restore.php
+++ b/src/S3Restore.php
@@ -6,6 +6,7 @@ namespace Keboola\ProjectRestore;
 
 use Keboola\Csv\CsvFile;
 use Keboola\ProjectRestore\StorageApi\BucketInfo;
+use Keboola\ProjectRestore\StorageApi\ConfigurationFilter;
 use Keboola\ProjectRestore\StorageApi\Token;
 use Keboola\StorageApi\Client as StorageApi;
 use Aws\S3\S3Client;
@@ -510,7 +511,9 @@ class S3Restore
                     'Configuration %s restored from backup',
                     $componentConfiguration["id"]
                 ));
-                $configuration->setConfiguration($configurationData->configuration);
+                $configuration->setConfiguration(
+                    ConfigurationFilter::removeOauthAuthorization($configurationData->configuration)
+                );
                 if (isset($configurationData->state)) {
                     $configuration->setState($configurationData->state);
                 }

--- a/src/StorageApi/ConfigurationFilter.php
+++ b/src/StorageApi/ConfigurationFilter.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Keboola\ProjectRestore\StorageApi;
 
+use stdClass;
+
 class ConfigurationFilter
 {
 
-    public static function removeOauthAuthorization(array $configuration): array
+    public static function removeOauthAuthorization(stdClass $configuration): stdClass
     {
-        if (isset($configuration['authorization']['oauth_api']['id'])) {
-            unset($configuration['authorization']['oauth_api']['id']);
+        if (isset($configuration->authorization->oauth_api->id)) {
+            unset($configuration->authorization->oauth_api->id);
             return $configuration;
         }
         return $configuration;

--- a/src/StorageApi/ConfigurationFilter.php
+++ b/src/StorageApi/ConfigurationFilter.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\ProjectRestore\StorageApi;
+
+class ConfigurationFilter
+{
+
+    public static function removeOauthAuthorization(array $configuration): array
+    {
+        if (isset($configuration['authorization']['oauth_api']['id'])) {
+            unset($configuration['authorization']['oauth_api']['id']);
+            return $configuration;
+        }
+        return $configuration;
+    }
+}

--- a/tests/ConfigurationFilterTest.php
+++ b/tests/ConfigurationFilterTest.php
@@ -15,8 +15,10 @@ class ConfigurationFilterTest extends \PHPUnit_Framework_TestCase
      */
     public function testOauthFilter(array $inConfigData, array $expectedOutConfigData): void
     {
-        $filteredConfigData = ConfigurationFilter::removeOauthAuthorization($inConfigData);
-        $this->assertEquals($expectedOutConfigData, $filteredConfigData);
+        $filteredConfigData = ConfigurationFilter::removeOauthAuthorization(
+            json_decode(json_encode($inConfigData))
+        );
+        $this->assertEquals(json_decode(json_encode($expectedOutConfigData)), $filteredConfigData);
     }
 
     public function oauthFilterData(): array
@@ -44,7 +46,7 @@ class ConfigurationFilterTest extends \PHPUnit_Framework_TestCase
                         'something' => 'value',
                     ],
                     'authorization' => [
-                        'oauth_api' => [],
+                        'oauth_api' => (object) [],
                     ],
                 ],
             ],

--- a/tests/ConfigurationFilterTest.php
+++ b/tests/ConfigurationFilterTest.php
@@ -19,7 +19,7 @@ class ConfigurationFilterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expectedOutConfigData, $filteredConfigData);
     }
 
-    public function oauthFilterData()
+    public function oauthFilterData(): array
     {
         return [
             'with-oauth' => [
@@ -32,7 +32,7 @@ class ConfigurationFilterTest extends \PHPUnit_Framework_TestCase
                     ],
                     'authorization' => [
                         'oauth_api' => [
-                            'id' => '123'
+                            'id' => '123',
                         ],
                     ],
                 ],

--- a/tests/ConfigurationFilterTest.php
+++ b/tests/ConfigurationFilterTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\ProjectRestore\Tests;
+
+use Keboola\ProjectRestore\StorageApi\ConfigurationFilter;
+
+class ConfigurationFilterTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider oauthFilterData
+     * @param array $inConfigData
+     * @param array $expectedOutConfigData
+     */
+    public function testOauthFilter(array $inConfigData, array $expectedOutConfigData): void
+    {
+        $filteredConfigData = ConfigurationFilter::removeOauthAuthorization($inConfigData);
+        $this->assertEquals($expectedOutConfigData, $filteredConfigData);
+    }
+
+    public function oauthFilterData()
+    {
+        return [
+            'with-oauth' => [
+                [
+                    'storage' => [
+                        'input' => [],
+                    ],
+                    'parameters' => [
+                        'something' => 'value',
+                    ],
+                    'authorization' => [
+                        'oauth_api' => [
+                            'id' => '123'
+                        ],
+                    ],
+                ],
+                [
+                    'storage' => [
+                        'input' => [],
+                    ],
+                    'parameters' => [
+                        'something' => 'value',
+                    ],
+                    'authorization' => [
+                        'oauth_api' => [],
+                    ],
+                ],
+            ],
+            'without-oauth' => [
+                [
+                    'storage' => [
+                        'input' => [],
+                    ],
+                    'parameters' => [
+                        'something' => 'value',
+                    ],
+                ],
+                [
+                    'storage' => [
+                        'input' => [],
+                    ],
+                    'parameters' => [
+                        'something' => 'value',
+                    ],
+                ],
+            ],
+            'with-weird-oauth' => [
+                [
+                    'storage' => [
+                        'input' => [],
+                    ],
+                    'parameters' => [
+                        'something' => 'value',
+                    ],
+                    'authorization' => [
+                        'oauth_api_v123' => [
+                            'something' => 'another',
+                        ],
+                    ],
+                ],
+                [
+                    'storage' => [
+                        'input' => [],
+                    ],
+                    'parameters' => [
+                        'something' => 'value',
+                    ],
+                    'authorization' => [
+                        'oauth_api_v123' => [
+                            'something' => 'another',
+                        ],
+                    ],
+                ],
+            ],
+            'with-injection-oauth' => [
+                [
+                    'storage' => [
+                        'input' => [],
+                    ],
+                    'parameters' => [
+                        'something' => 'value',
+                    ],
+                    'authorization' => [
+                        'oauth_api' => [
+                            'credentials' => [
+                                '#data' => 'value',
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'storage' => [
+                        'input' => [],
+                    ],
+                    'parameters' => [
+                        'something' => 'value',
+                    ],
+                    'authorization' => [
+                        'oauth_api' => [
+                            'credentials' => [
+                                '#data' => 'value',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/S3RestoreTest.php
+++ b/tests/S3RestoreTest.php
@@ -493,7 +493,9 @@ class S3RestoreTest extends BaseTest
 
         $config = $components->getConfiguration("keboola.ex-slack", '213957518');
         $expectedConfigData = json_decode(
-            file_get_contents(__DIR__ . '/data/backups/configurations/configurations/keboola.ex-slack/213957518.json'), true)['configuration'];
+            file_get_contents(__DIR__ . '/data/backups/configurations/configurations/keboola.ex-slack/213957518.json'),
+            true
+        )['configuration'];
         $expectedConfigData['authorization']['oauth_api'] = [];
         self::assertEquals(2, $config["version"]);
         self::assertEquals("Configuration 213957518 restored from backup", $config["changeDescription"]);

--- a/tests/S3RestoreTest.php
+++ b/tests/S3RestoreTest.php
@@ -486,11 +486,19 @@ class S3RestoreTest extends BaseTest
         self::assertEquals("Accounts", $config["name"]);
         self::assertEquals("Default CSV Importer", $config["description"]);
         self::assertEquals(["key" => "value"], $config["state"]);
+        self::assertEquals(
+            json_decode(file_get_contents(__DIR__ . '/data/backups/configurations/configurations/keboola.csv-import/213957449.json'), true),
+            $config['configuration']
+        );
 
         $config = $components->getConfiguration("keboola.ex-slack", '213957518');
         self::assertEquals(2, $config["version"]);
         self::assertEquals("Configuration 213957518 restored from backup", $config["changeDescription"]);
         self::assertEmpty($config["state"]);
+        self::assertEquals(
+            json_decode(file_get_contents(__DIR__ . '/data/backups/configurations/configurations/keboola.ex-slack/213957518.json'), true),
+            $config['configuration']
+        );
     }
 
     public function testRestoreConfigurationsWithoutVersions(): void

--- a/tests/S3RestoreTest.php
+++ b/tests/S3RestoreTest.php
@@ -487,18 +487,18 @@ class S3RestoreTest extends BaseTest
         self::assertEquals("Default CSV Importer", $config["description"]);
         self::assertEquals(["key" => "value"], $config["state"]);
         self::assertEquals(
-            json_decode(file_get_contents(__DIR__ . '/data/backups/configurations/configurations/keboola.csv-import/213957449.json'), true),
+            json_decode(file_get_contents(__DIR__ . '/data/backups/configurations/configurations/keboola.csv-import/213957449.json'), true)['configuration'],
             $config['configuration']
         );
 
         $config = $components->getConfiguration("keboola.ex-slack", '213957518');
+        $expectedConfigData = json_decode(
+            file_get_contents(__DIR__ . '/data/backups/configurations/configurations/keboola.ex-slack/213957518.json'), true)['configuration'];
+        $expectedConfigData['authorization']['oauth_api'] = [];
         self::assertEquals(2, $config["version"]);
         self::assertEquals("Configuration 213957518 restored from backup", $config["changeDescription"]);
         self::assertEmpty($config["state"]);
-        self::assertEquals(
-            json_decode(file_get_contents(__DIR__ . '/data/backups/configurations/configurations/keboola.ex-slack/213957518.json'), true),
-            $config['configuration']
-        );
+        self::assertEquals($expectedConfigData, $config['configuration']);
     }
 
     public function testRestoreConfigurationsWithoutVersions(): void


### PR DESCRIPTION
Odstraní z konfigurací OAuth komponent referenci na neexistující záznam v OAuth API. Všechny OAuth appky je nutné po restore znovu autorizovat.