### PR TITLE
Fix type of columnName

### DIFF
--- a/src/Restore.php
+++ b/src/Restore.php
@@ -642,6 +642,7 @@ abstract class Restore
             $columns[$column] = [];
         }
         foreach ($tableInfo['columnMetadata'] ?? [] as $columnName => $column) {
+            $columnName = strval($columnName);
             $columnMetadata = [];
             foreach ($column as $metadata) {
                 if ($metadata['provider'] !== 'storage') {
@@ -661,8 +662,8 @@ abstract class Restore
                 $definition['default'] = $columnMetadata['KBC.datatype.default'];
             }
 
-            $columns[(string) $columnName] = [
-                'name' => (string) $columnName,
+            $columns[$columnName] = [
+                'name' => $columnName,
                 'definition' => $definition,
                 'basetype' => $columnMetadata['KBC.datatype.basetype'],
             ];

--- a/src/Restore.php
+++ b/src/Restore.php
@@ -661,8 +661,8 @@ abstract class Restore
                 $definition['default'] = $columnMetadata['KBC.datatype.default'];
             }
 
-            $columns[$columnName] = [
-                'name' => $columnName,
+            $columns[(string) $columnName] = [
+                'name' => (string) $columnName,
                 'definition' => $definition,
                 'basetype' => $columnMetadata['KBC.datatype.basetype'],
             ];

--- a/tests/AbsRestoreTest.php
+++ b/tests/AbsRestoreTest.php
@@ -267,6 +267,8 @@ class AbsRestoreTest extends BaseTest
         );
         $restore->restorePermanentFiles();
 
+        sleep(3);
+
         $files = $this->sapiClient->listFiles();
         $permanentFiles = array_filter($files, function ($file) {
             return is_null($file['maxAgeDays']);

--- a/tests/S3RestoreTest.php
+++ b/tests/S3RestoreTest.php
@@ -280,6 +280,8 @@ class S3RestoreTest extends BaseTest
         );
         $restore->restorePermanentFiles();
 
+        sleep(3);
+
         $files = $this->sapiClient->listFiles();
         $permanentFiles = array_filter($files, function ($file) {
             return is_null($file['maxAgeDays']);


### PR DESCRIPTION
Changes:

- Fix type of columnName to prevent errors when setting types and columnName is numeric

---

Error looked like:
```
 "Invalid request: - columns[20][name]: "This value should be of type string.""
````