### PR TITLE
fix empty tables in triggers

### DIFF
--- a/src/Restore.php
+++ b/src/Restore.php
@@ -811,7 +811,11 @@ abstract class Restore
          * } $trigger
          */
         foreach ($triggers as $trigger) {
-            $this->logger->info(sprintf('Restoring trigger %s', $trigger['id']));
+            if (!$trigger['tables']) {
+                $this->logger->info(sprintf('Skipping trigger "%s" - no tables', $trigger['id']));
+                continue;
+            }
+            $this->logger->info(sprintf('Restoring trigger "%s"', $trigger['id']));
             $tokenOptions = new TokenCreateOptions();
             $tokenOptions->setDescription(sprintf(
                 '[_internal] Token for triggering %s',

--- a/tests/AbsRestoreTest.php
+++ b/tests/AbsRestoreTest.php
@@ -972,10 +972,12 @@ class AbsRestoreTest extends BaseTest
 
     public function testRestoreTriggers(): void
     {
+        $logger = new TestLogger();
         $restore = new AbsRestore(
             $this->sapiClient,
             $this->absClient,
             getenv('TEST_AZURE_CONTAINER_NAME') . '-triggers',
+            $logger,
         );
 
         $restore->restoreBuckets();
@@ -1007,6 +1009,8 @@ class AbsRestoreTest extends BaseTest
 ]
 JSON;
 
+        self::assertTrue($logger->hasInfo('Skipping trigger "1111" - no tables'));
+        self::assertTrue($logger->hasInfo('Restoring trigger "2222"'));
         self::assertStringMatchesFormat($expectedResult, (string) json_encode($triggers, JSON_PRETTY_PRINT));
     }
 

--- a/tests/S3RestoreTest.php
+++ b/tests/S3RestoreTest.php
@@ -1009,11 +1009,13 @@ class S3RestoreTest extends BaseTest
 
     public function testRestoreTriggers(): void
     {
+        $logger = new TestLogger();
         $restore = new S3Restore(
             $this->sapiClient,
             $this->s3Client,
             (string) getenv('TEST_AWS_S3_BUCKET'),
             'triggers',
+            $logger,
         );
 
         $restore->restoreBuckets();
@@ -1045,6 +1047,8 @@ class S3RestoreTest extends BaseTest
 ]
 JSON;
 
+        self::assertTrue($logger->hasInfo('Skipping trigger "1111" - no tables'));
+        self::assertTrue($logger->hasInfo('Restoring trigger "2222"'));
         self::assertStringMatchesFormat($expectedResult, (string) json_encode($triggers, JSON_PRETTY_PRINT));
     }
 

--- a/tests/data/backups/triggers/triggers.json
+++ b/tests/data/backups/triggers/triggers.json
@@ -1,5 +1,5 @@
 [{
-  "id": "2367",
+  "id": "2222",
   "runWithTokenId": 982885,
   "component": "keboola.orchestrator",
   "configurationId": "1077426543",
@@ -12,4 +12,17 @@
   "tables": [{
     "tableId": "in.c-bucket.firstTable"
   }]
+},
+{
+  "id": "1111",
+  "runWithTokenId": 1234,
+  "component": "keboola.orchestrator",
+  "configurationId": "1077426543",
+  "lastRun": "2024-09-01T05:53:50+0100",
+  "creatorToken": {
+    "id": 157401,
+    "description": "ondrej.jodas@keboola.com"
+  },
+  "coolDownPeriodMinutes": 5,
+  "tables": []
 }]


### PR DESCRIPTION
Nyní nejde založit event trigger který by neměl nakonfigurovanou žádnou tabulku, ale v minulosti to buď šlo a nebo se někomu podařilo do toho stavu dostat. No takový trigger (který nemá tables) nejde založit a proto ho musíme skipnout

A jelikož nejde takový trigger založit tak mi to při implementaci moc nedocvaklo