### PR TITLE
fix: prevent configuration creation in dry-run mode

### DIFF
--- a/src/Restore.php
+++ b/src/Restore.php
@@ -158,7 +158,16 @@ abstract class Restore
                 if ($componentId === self::ORCHESTRATOR_COMPONENT_ID) {
                     $configuration->setIsDisabled(true);
                 }
-                $components->addConfiguration($configuration);
+
+                if ($this->dryRun === false) {
+                    $components->addConfiguration($configuration);
+                } else {
+                    $this->logger->info(sprintf(
+                        '[dry-run] Create configuration %s (component "%s")',
+                        $componentConfiguration['id'],
+                        $componentId,
+                    ));
+                }
 
                 // update configuration and state
                 $configuration->setChangeDescription(sprintf(
@@ -179,7 +188,7 @@ abstract class Restore
                     $components->updateConfiguration($configuration);
                 } else {
                     $this->logger->info(sprintf(
-                        '[dry-run] Restore configuration %s (component "%s")',
+                        '[dry-run] Update configuration %s (component "%s")',
                         $componentConfiguration['id'],
                         $componentId,
                     ));


### PR DESCRIPTION
When running in dry-run mode, configurations should not be created in the target project. This PR adds a condition to prevent configuration creation in dry-run mode.