### PR TITLE
DMD-103: stop use deprecated shareBucket

### DIFF
--- a/tests/StorageApi/BucketInfoTest.php
+++ b/tests/StorageApi/BucketInfoTest.php
@@ -96,7 +96,7 @@ class BucketInfoTest extends BaseTest
 
         $bucketId = $this->createTestBucket();
 
-        $this->sapiClient->shareBucket($bucketId, ['sharing' => 'organization']);
+        $this->sapiClient->shareOrganizationBucket($bucketId, true);
         $linkedBucketId = $this->sapiClient->linkBucket(
             self::BUCKET_NAME,
             Client::STAGE_OUT,


### PR DESCRIPTION
- use shareOrganizationBucket async=true

Upravujem volane methody sapi klienta (mazem pouzitie deprecated metody a nahradil som ju novou) aby sa to volalo async tych synchronnych akcii sa chceme zbavit. Client si sam handluje kedy skonci job takze ine zmeny niesu potreba