### PR TITLE
chore: reduce metadata batch size from 100 to 50

### DIFF
--- a/src/Restore.php
+++ b/src/Restore.php
@@ -49,7 +49,7 @@ abstract class Restore
 
     private const ORCHESTRATOR_COMPONENT_ID = 'keboola.orchestrator';
 
-    private const METADATA_BATCH_SIZE = 100;
+    private const METADATA_BATCH_SIZE = 50;
 
     protected bool $dryRun = false;
 

--- a/tests/AbsRestoreTest.php
+++ b/tests/AbsRestoreTest.php
@@ -954,15 +954,18 @@ class AbsRestoreTest extends BaseTest
             self::assertEquals("value_{$i}", $table['columnMetadata'][$columnName][0]['value']);
         }
 
-        // Verify batching logs (150 columns should be split into 2 batches of 100 and 50)
+        // Verify batching logs (150 columns should be split into 3 batches of 50 each)
         self::assertTrue($testHandler->hasInfoThatContains(
-            'Processing table in.c-bucket.LargeTable metadata in 2 batches',
+            'Processing table in.c-bucket.LargeTable metadata in 3 batches',
         ));
         self::assertTrue($testHandler->hasInfoThatContains(
-            'Processed batch 1/2 for table in.c-bucket.LargeTable',
+            'Processed batch 1/3 for table in.c-bucket.LargeTable',
         ));
         self::assertTrue($testHandler->hasInfoThatContains(
-            'Processed batch 2/2 for table in.c-bucket.LargeTable',
+            'Processed batch 2/3 for table in.c-bucket.LargeTable',
+        ));
+        self::assertTrue($testHandler->hasInfoThatContains(
+            'Processed batch 3/3 for table in.c-bucket.LargeTable',
         ));
     }
 

--- a/tests/GcsRestoreTest.php
+++ b/tests/GcsRestoreTest.php
@@ -901,15 +901,18 @@ class GcsRestoreTest extends BaseTest
             self::assertEquals("value_{$i}", $table['columnMetadata'][$columnName][0]['value']);
         }
 
-        // Verify batching logs (150 columns should be split into 2 batches of 100 and 50)
+        // Verify batching logs (150 columns should be split into 3 batches of 50 each)
         self::assertTrue($testHandler->hasInfoThatContains(
-            'Processing table in.c-bucket.LargeTable metadata in 2 batches',
+            'Processing table in.c-bucket.LargeTable metadata in 3 batches',
         ));
         self::assertTrue($testHandler->hasInfoThatContains(
-            'Processed batch 1/2 for table in.c-bucket.LargeTable',
+            'Processed batch 1/3 for table in.c-bucket.LargeTable',
         ));
         self::assertTrue($testHandler->hasInfoThatContains(
-            'Processed batch 2/2 for table in.c-bucket.LargeTable',
+            'Processed batch 2/3 for table in.c-bucket.LargeTable',
+        ));
+        self::assertTrue($testHandler->hasInfoThatContains(
+            'Processed batch 3/3 for table in.c-bucket.LargeTable',
         ));
     }
 

--- a/tests/S3RestoreTest.php
+++ b/tests/S3RestoreTest.php
@@ -977,15 +977,18 @@ class S3RestoreTest extends BaseTest
             self::assertEquals("value_{$i}", $table['columnMetadata'][$columnName][0]['value']);
         }
 
-        // Verify batching logs (150 columns should be split into 2 batches of 100 and 50)
+        // Verify batching logs (150 columns should be split into 3 batches of 50 each)
         self::assertTrue($testHandler->hasInfoThatContains(
-            'Processing table in.c-bucket.LargeTable metadata in 2 batches',
+            'Processing table in.c-bucket.LargeTable metadata in 3 batches',
         ));
         self::assertTrue($testHandler->hasInfoThatContains(
-            'Processed batch 1/2 for table in.c-bucket.LargeTable',
+            'Processed batch 1/3 for table in.c-bucket.LargeTable',
         ));
         self::assertTrue($testHandler->hasInfoThatContains(
-            'Processed batch 2/2 for table in.c-bucket.LargeTable',
+            'Processed batch 2/3 for table in.c-bucket.LargeTable',
+        ));
+        self::assertTrue($testHandler->hasInfoThatContains(
+            'Processed batch 3/3 for table in.c-bucket.LargeTable',
         ));
     }
 


### PR DESCRIPTION
Follow up  https://linear.app/keboola/issue/AJDA-1274/project-migrations-restore-table-metadata-split-to-chunks

## Release Notes

  - Changed batch size for column metadata from 100 to 50 columns

  ## Change Type

  Fix

  ## Impact Analysis

  - Affects users restoring backups of tables with 100+ columns from any cloud storage backend (AWS S3, Azure Blob Storage, Google Cloud
  Storage)
  - Improves success rate for restoring projects with wide tables that previously failed during metadata restoration
  - No risk to existing functionality — tables with fewer columns continue using the fast single-batch approach

  ## Customer Communication Plans

No communication needed

  ## Justification

  Tables with large numbers of columns were failing during backup restoration because the metadata upload was too large for AWS SNS message limits. This change breaks large metadata updates into manageable batches of 100 columns, allowing successful restoration regardless of table width.

  ## Deployment Plan

Merge and release a new version of `keboola/kbc-project-restore` lib. Then update dependencies in Project Migration - Restore App.


  ## Rollback Plan

Fix dependencies in Project Migration - Restore App to previous version.


  ## Post-Release Support Plan

N/A