### PR TITLE
[AJDA-2414] Parallelize table creation in restoreTables()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
         "keboola/php-temp": "^2.0",
         "keboola/storage-api-client": "^15.2",
         "monolog/monolog": "^2.3",
-        "keboola/notification-api-php-client": "^3.0"
+        "keboola/notification-api-php-client": "^3.0",
+        "symfony/process": "^6.0"
     },
     "require-dev": {
         "cweagans/composer-patches": "^1.7",

--- a/src/Restore.php
+++ b/src/Restore.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Keboola\ProjectRestore;
 
 use Closure;
+use Composer\Autoload\ClassLoader;
 use Keboola\Csv\CsvFile;
 use Keboola\Datatype\Definition\Bigquery;
 use Keboola\Datatype\Definition\Snowflake;
@@ -36,6 +37,7 @@ use Keboola\StorageApi\Tokens;
 use Keboola\Temp\Temp;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use ReflectionClass;
 use RuntimeException;
 use stdClass;
 use Symfony\Component\Process\Process;
@@ -769,6 +771,9 @@ abstract class Restore
         if ($this->workerProcessFactory !== null) {
             return ($this->workerProcessFactory)($input);
         }
+
+        $classLoaderFile = (new ReflectionClass(ClassLoader::class))->getFileName();
+        $input['autoloadPath'] = dirname((string) $classLoaderFile, 2) . '/autoload.php';
 
         $process = new Process([PHP_BINARY, __DIR__ . '/worker-create-table.php']);
         $process->setInput((string) json_encode($input));

--- a/src/Restore.php
+++ b/src/Restore.php
@@ -608,7 +608,8 @@ abstract class Restore
         }
 
         // Phase 2: parallel table creation
-        $createdTableIds = $this->createTablesParallel($workItems);
+        // Interleave by bucket so workers always operate on different buckets concurrently.
+        $createdTableIds = $this->createTablesParallel($this->interleaveByBucket($workItems));
 
         // Phase 3: sequential metadata + data upload
         $tmp = new Temp();
@@ -784,6 +785,35 @@ abstract class Restore
         $process->setInput((string) json_encode($input, JSON_THROW_ON_ERROR));
         $process->setTimeout(3600);
         return $process;
+    }
+
+    /**
+     * Reorder work items so consecutive entries come from different buckets.
+     * This maximises parallelism when workers cannot run concurrently within the same bucket.
+     *
+     * @param array<int, array{tableInfo: array<mixed>, workerInput: array<string, mixed>}> $workItems
+     * @return array<int, array{tableInfo: array<mixed>, workerInput: array<string, mixed>}>
+     */
+    private function interleaveByBucket(array $workItems): array
+    {
+        $byBucket = [];
+        foreach ($workItems as $item) {
+            /** @var array{id: string} $bucket */
+            $bucket = $item['tableInfo']['bucket'];
+            $byBucket[$bucket['id']][] = $item;
+        }
+
+        $result = [];
+        while ($byBucket !== []) {
+            foreach ($byBucket as $bucketId => $items) {
+                $result[] = array_shift($byBucket[$bucketId]);
+                if ($byBucket[$bucketId] === []) {
+                    unset($byBucket[$bucketId]);
+                }
+            }
+        }
+
+        return $result;
     }
 
     /**

--- a/src/Restore.php
+++ b/src/Restore.php
@@ -576,7 +576,7 @@ abstract class Restore
                 'isTyped' => $isTyped,
                 'bucketId' => $bucketId,
                 'tableName' => $tableInfo['name'],
-                'displayName' => $tableInfo['displayName'],
+                'displayName' => $tableInfo['displayName'] ?? $tableInfo['name'],
                 'columns' => $tableInfo['columns'],
                 'primaryKey' => $tableInfo['primaryKey'],
             ];

--- a/src/Restore.php
+++ b/src/Restore.php
@@ -774,6 +774,7 @@ abstract class Restore
 
         $classLoaderFile = (new ReflectionClass(ClassLoader::class))->getFileName();
         $input['autoloadPath'] = dirname((string) $classLoaderFile, 2) . '/autoload.php';
+        $input['runId'] = $this->sapiClient->getRunId();
 
         $process = new Process([PHP_BINARY, __DIR__ . '/worker-create-table.php']);
         $process->setInput((string) json_encode($input));

--- a/src/Restore.php
+++ b/src/Restore.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Keboola\ProjectRestore;
 
+use Closure;
 use Keboola\Csv\CsvFile;
 use Keboola\Datatype\Definition\Bigquery;
 use Keboola\Datatype\Definition\Snowflake;
@@ -35,7 +36,10 @@ use Keboola\StorageApi\Tokens;
 use Keboola\Temp\Temp;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use RuntimeException;
 use stdClass;
+use Symfony\Component\Process\Process;
+use Throwable;
 
 abstract class Restore
 {
@@ -54,6 +58,11 @@ abstract class Restore
     protected bool $dryRun = false;
 
     private bool $forcePrimaryKeyNotNull = false;
+
+    private int $parallelism = 5;
+
+    /** @var Closure(array<string, mixed>): Process|null */
+    private ?Closure $workerProcessFactory = null;
 
     public function __construct(Client $sapiClient, ?LoggerInterface $logger = null)
     {
@@ -82,6 +91,17 @@ abstract class Restore
     public function setForcePrimaryKeyNotNull(bool $force = true): void
     {
         $this->forcePrimaryKeyNotNull = $force;
+    }
+
+    public function setParallelism(int $parallelism): void
+    {
+        $this->parallelism = $parallelism;
+    }
+
+    /** @param Closure(array<string, mixed>): Process $factory */
+    public function setWorkerProcessFactory(Closure $factory): void
+    {
+        $this->workerProcessFactory = $factory;
     }
 
     public function restoreProjectMetadata(): void
@@ -514,8 +534,6 @@ abstract class Restore
     {
         $this->logger->info('Downloading tables');
 
-        $tmp = new Temp();
-
         $fileContent = $this->getDataFromStorage('tables.json');
         /** @var array $tables */
         $tables = json_decode((string) $fileContent, true);
@@ -525,6 +543,9 @@ abstract class Restore
 
         $metadataClient = new Metadata($this->sapiClient);
 
+        // Phase 1: prepare worker inputs (fast, no SAPI I/O)
+        /** @var array<int, array{tableInfo: array<mixed>, workerInput: array<string, mixed>}> $workItems */
+        $workItems = [];
         /** @var array $tableInfo */
         foreach ($tables as $tableInfo) {
             if ($tableInfo['isAlias'] === true) {
@@ -532,43 +553,79 @@ abstract class Restore
             }
             $this->checkTableRestorable($tableInfo);
 
-            $tableId = $tableInfo['id'];
+            $originalTableId = $tableInfo['id'];
             $bucketId = $tableInfo['bucket']['id'];
 
             if (!in_array($bucketId, array_keys($restoredBuckets))) {
-                $this->logger->warning(sprintf('Skipping table %s', $tableId));
+                $this->logger->warning(sprintf('Skipping table %s', $originalTableId));
                 continue;
             }
 
-            $this->logger->info(sprintf('Restoring table %s', $tableId));
+            $this->logger->info(sprintf('Restoring table %s', $originalTableId));
 
             if ($this->dryRun === true) {
-                $this->logger->info(sprintf('[dry-run] Restore table %s', $tableId));
-                // skip all code bellow in dry-run mode
+                $this->logger->info(sprintf('[dry-run] Restore table %s', $originalTableId));
+                continue;
+            }
+
+            $isTyped = $tableInfo['isTyped'] ?? false;
+            /** @var array<string, mixed> $workerInput */
+            $workerInput = [
+                'sapiUrl' => $this->sapiClient->getApiUrl(),
+                'sapiToken' => $this->sapiClient->getTokenString(),
+                'isTyped' => $isTyped,
+                'bucketId' => $bucketId,
+                'tableName' => $tableInfo['name'],
+                'columns' => $tableInfo['columns'],
+                'primaryKey' => $tableInfo['primaryKey'],
+            ];
+
+            if (isset($tableInfo['displayName'])) {
+                $workerInput['displayName'] = $tableInfo['displayName'];
+            }
+
+            if ($isTyped) {
+                $workerInput['tableDefinition'] = $this->buildTypedTableDefinition(
+                    $tableInfo,
+                    $restoredBuckets[$bucketId],
+                );
+            }
+
+            $workItems[] = [
+                'tableInfo' => $tableInfo,
+                'workerInput' => $workerInput,
+            ];
+        }
+
+        if ($workItems === []) {
+            return;
+        }
+
+        // Phase 2: parallel table creation
+        $createdTableIds = $this->createTablesParallel($workItems);
+
+        // Phase 3: sequential metadata + data upload
+        $tmp = new Temp();
+        foreach ($workItems as $workItem) {
+            $tableInfo = $workItem['tableInfo'];
+            $originalTableId = $tableInfo['id'];
+            $tableId = $createdTableIds[$originalTableId] ?? null;
+            if ($tableId === null) {
+                continue;
+            }
+
+            $this->restoreTableColumnsMetadata($tableInfo, $tableId, $metadataClient);
+
+            $slices = $this->listTableFiles($tableId);
+
+            // no files for the table found, probably an empty table
+            if (count($slices) === 0) {
                 continue;
             }
 
             $headerFile = $tmp->createFile(sprintf('%s.header.csv', $tableInfo['id']));
             $headerFile = new CsvFile($headerFile->getPathname());
             $headerFile->writeRow($tableInfo['columns']);
-
-            $isTyped = $tableInfo['isTyped'] ?? false;
-            if ($isTyped) {
-                $tableId = $this->restoreTypedTable($tableInfo, $restoredBuckets[$bucketId]);
-            } else {
-                $tableId = $this->restoreTable($tableInfo, $headerFile);
-            }
-
-            $this->restoreTableColumnsMetadata($tableInfo, $tableId, $metadataClient);
-
-            // upload data
-            $slices = $this->listTableFiles($tableId);
-
-            // no files for the table found, probably an empty table
-            if (count($slices) === 0) {
-                unset($headerFile);
-                continue;
-            }
 
             $firstSlice = reset($slices);
             if (count($slices) === 1 && substr($firstSlice, -14) !== '.part_0.csv.gz') {
@@ -623,6 +680,103 @@ abstract class Restore
     }
 
     /**
+     * @param array<int, array{tableInfo: array<mixed>, workerInput: array<string, mixed>}> $workItems
+     * @return array<string, string> map of originalTableId => createdTableId
+     */
+    private function createTablesParallel(array $workItems): array
+    {
+        $pendingItems = $workItems;
+        /** @var array<string, array{process: Process, tableInfo: array<mixed>}> $runningProcesses */
+        $runningProcesses = [];
+        /** @var array<string, string> $createdTableIds */
+        $createdTableIds = [];
+        /** @var Throwable[] $errors */
+        $errors = [];
+
+        try {
+            while ($pendingItems !== [] || $runningProcesses !== []) {
+                while (count($runningProcesses) < $this->parallelism && $pendingItems !== []) {
+                    $item = array_shift($pendingItems);
+                    /** @var string $originalTableId */
+                    $originalTableId = $item['tableInfo']['id'];
+                    $process = $this->createWorkerProcess($item['workerInput']);
+                    $process->start();
+                    $runningProcesses[$originalTableId] = [
+                        'process' => $process,
+                        'tableInfo' => $item['tableInfo'],
+                    ];
+                }
+
+                foreach ($runningProcesses as $originalTableId => $running) {
+                    if ($running['process']->isRunning()) {
+                        continue;
+                    }
+                    unset($runningProcesses[$originalTableId]);
+
+                    /** @var array{tableId?: string, error?: string, code?: int, isNullablePkError?: bool, isClientException?: bool}|null $output */
+                    $output = json_decode($running['process']->getOutput(), true);
+
+                    if ($running['process']->getExitCode() !== 0 || isset($output['error'])) {
+                        $errorMessage = ($output !== null && isset($output['error']))
+                            ? (string) $output['error']
+                            : $running['process']->getErrorOutput();
+
+                        if ($output !== null && ($output['isNullablePkError'] ?? false)) {
+                            /** @var array{name: string} $tableInfo */
+                            $tableInfo = $running['tableInfo'];
+                            $errors[] = new StorageApiException(sprintf(
+                                'Table "%s" cannot be restored because the primary key cannot be'
+                                . ' set on a nullable column.',
+                                $tableInfo['name'],
+                            ));
+                        } elseif ($output !== null && ($output['isClientException'] ?? false)) {
+                            $errors[] = new ClientException($errorMessage, (int) ($output['code'] ?? 0));
+                        } else {
+                            $errors[] = new RuntimeException(sprintf(
+                                'Failed to create table %s: %s',
+                                $originalTableId,
+                                $errorMessage,
+                            ));
+                        }
+                        continue;
+                    }
+
+                    $createdTableIds[$originalTableId] = (string) ($output['tableId'] ?? $originalTableId);
+                }
+
+                if ($runningProcesses !== []) {
+                    usleep(100000);
+                }
+            }
+        } finally {
+            foreach ($runningProcesses as $running) {
+                if ($running['process']->isRunning()) {
+                    $running['process']->stop();
+                }
+            }
+        }
+
+        if ($errors !== []) {
+            throw $errors[0];
+        }
+
+        return $createdTableIds;
+    }
+
+    /** @param array<string, mixed> $input */
+    private function createWorkerProcess(array $input): Process
+    {
+        if ($this->workerProcessFactory !== null) {
+            return ($this->workerProcessFactory)($input);
+        }
+
+        $process = new Process([PHP_BINARY, __DIR__ . '/worker-create-table.php']);
+        $process->setInput((string) json_encode($input));
+        $process->setTimeout(3600);
+        return $process;
+    }
+
+    /**
      * @return array<string|int, array<int, array{key: string, value: string, columnName?: string}>>
      */
     private function prepareMetadata(array $rawMetadata): array
@@ -673,27 +827,8 @@ abstract class Restore
 
     abstract protected function listTableFiles(string $tableId): array;
 
-    private function restoreTable(array $tableInfo, CsvFile $headerFile): string
-    {
-        // create empty table
-        $tableId = $this->sapiClient->createTableAsync(
-            $tableInfo['bucket']['id'],
-            $tableInfo['name'],
-            $headerFile,
-            [
-                'primaryKey' => join(',', $tableInfo['primaryKey']),
-            ],
-        );
-
-        if (isset($tableInfo['displayName'])) {
-            $this->sapiClient->updateTable($tableId, [
-                'displayName' => $tableInfo['displayName'],
-            ]);
-        }
-        return $tableId;
-    }
-
-    private function restoreTypedTable(array $tableInfo, string $destinationBucketBackendType): string
+    /** @return array<string, mixed> */
+    private function buildTypedTableDefinition(array $tableInfo, string $destinationBucketBackendType): array
     {
         $columns = [];
         foreach ($tableInfo['columns'] as $column) {
@@ -779,28 +914,7 @@ abstract class Restore
             ];
         }
 
-        try {
-            $tableId = $this->sapiClient->createTableDefinition(
-                $tableInfo['bucket']['id'],
-                $data,
-            );
-
-            if (isset($tableInfo['displayName'])) {
-                $this->sapiClient->updateTable($tableId, [
-                    'displayName' => $tableInfo['displayName'],
-                ]);
-            }
-            return $tableId;
-        } catch (ClientException $e) {
-            if ($e->getCode() === 400
-                && preg_match('/Primary keys columns must be set nullable false/', $e->getMessage())) {
-                throw new StorageApiException(sprintf(
-                    'Table "%s" cannot be restored because the primary key cannot be set on a nullable column.',
-                    $tableInfo['name'],
-                ));
-            }
-            throw $e;
-        }
+        return $data;
     }
 
     private function validateSnowflakeToBigqueryNumericScale(

--- a/src/Restore.php
+++ b/src/Restore.php
@@ -62,8 +62,6 @@ abstract class Restore
 
     private bool $forcePrimaryKeyNotNull = false;
 
-    private int $parallelism = 5;
-
     /** @var Closure(array<string, mixed>): Process|null */
     private ?Closure $workerProcessFactory = null;
 
@@ -94,14 +92,6 @@ abstract class Restore
     public function setForcePrimaryKeyNotNull(bool $force = true): void
     {
         $this->forcePrimaryKeyNotNull = $force;
-    }
-
-    public function setParallelism(int $parallelism): void
-    {
-        if ($parallelism < 1) {
-            throw new InvalidArgumentException('Parallelism must be at least 1.');
-        }
-        $this->parallelism = $parallelism;
     }
 
     /** @param Closure(array<string, mixed>): Process $factory */
@@ -536,8 +526,12 @@ abstract class Restore
         }
     }
 
-    public function restoreTables(): void
+    public function restoreTables(int $parallelism = 5): void
     {
+        if ($parallelism < 1) {
+            throw new InvalidArgumentException('Parallelism must be at least 1.');
+        }
+
         $this->logger->info('Downloading tables');
 
         $fileContent = $this->getDataFromStorage('tables.json');
@@ -609,7 +603,7 @@ abstract class Restore
 
         // Phase 2: parallel table creation
         // Interleave by bucket so workers always operate on different buckets concurrently.
-        $createdTableIds = $this->createTablesParallel($this->interleaveByBucket($workItems));
+        $createdTableIds = $this->createTablesParallel($this->interleaveByBucket($workItems), $parallelism);
 
         // Phase 3: sequential metadata + data upload
         $tmp = new Temp();
@@ -690,7 +684,7 @@ abstract class Restore
      * @param array<int, array{tableInfo: array<mixed>, workerInput: array<string, mixed>}> $workItems
      * @return array<string, string> map of originalTableId => createdTableId
      */
-    private function createTablesParallel(array $workItems): array
+    private function createTablesParallel(array $workItems, int $parallelism): array
     {
         $pendingItems = $workItems;
         /** @var array<string, array{process: Process, tableInfo: array<mixed>}> $runningProcesses */
@@ -702,7 +696,7 @@ abstract class Restore
 
         try {
             while ($pendingItems !== [] || $runningProcesses !== []) {
-                while (count($runningProcesses) < $this->parallelism && $pendingItems !== []) {
+                while (count($runningProcesses) < $parallelism && $pendingItems !== []) {
                     $item = array_shift($pendingItems);
                     /** @var string $originalTableId */
                     $originalTableId = $item['tableInfo']['id'];

--- a/src/Restore.php
+++ b/src/Restore.php
@@ -6,6 +6,7 @@ namespace Keboola\ProjectRestore;
 
 use Closure;
 use Composer\Autoload\ClassLoader;
+use InvalidArgumentException;
 use Keboola\Csv\CsvFile;
 use Keboola\Datatype\Definition\Bigquery;
 use Keboola\Datatype\Definition\Snowflake;
@@ -97,6 +98,9 @@ abstract class Restore
 
     public function setParallelism(int $parallelism): void
     {
+        if ($parallelism < 1) {
+            throw new InvalidArgumentException('Parallelism must be at least 1.');
+        }
         $this->parallelism = $parallelism;
     }
 
@@ -718,7 +722,7 @@ abstract class Restore
                     /** @var array{tableId?: string, error?: string, code?: int, isNullablePkError?: bool, isClientException?: bool}|null $output */
                     $output = json_decode($running['process']->getOutput(), true);
 
-                    if ($running['process']->getExitCode() !== 0 || isset($output['error'])) {
+                    if ($running['process']->getExitCode() !== 0 || !is_array($output) || isset($output['error'])) {
                         $errorMessage = ($output !== null && isset($output['error']))
                             ? (string) $output['error']
                             : $running['process']->getErrorOutput();
@@ -777,7 +781,7 @@ abstract class Restore
         $input['runId'] = $this->sapiClient->getRunId();
 
         $process = new Process([PHP_BINARY, __DIR__ . '/worker-create-table.php']);
-        $process->setInput((string) json_encode($input));
+        $process->setInput((string) json_encode($input, JSON_THROW_ON_ERROR));
         $process->setTimeout(3600);
         return $process;
     }

--- a/src/Restore.php
+++ b/src/Restore.php
@@ -576,13 +576,10 @@ abstract class Restore
                 'isTyped' => $isTyped,
                 'bucketId' => $bucketId,
                 'tableName' => $tableInfo['name'],
+                'displayName' => $tableInfo['displayName'],
                 'columns' => $tableInfo['columns'],
                 'primaryKey' => $tableInfo['primaryKey'],
             ];
-
-            if (isset($tableInfo['displayName'])) {
-                $workerInput['displayName'] = $tableInfo['displayName'];
-            }
 
             if ($isTyped) {
                 $workerInput['tableDefinition'] = $this->buildTypedTableDefinition(
@@ -758,6 +755,9 @@ abstract class Restore
         }
 
         if ($errors !== []) {
+            foreach ($errors as $error) {
+                $this->logger->warning(sprintf('Table creation failed: %s', $error->getMessage()));
+            }
             throw $errors[0];
         }
 

--- a/src/worker-create-table.php
+++ b/src/worker-create-table.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 $raw = json_decode((string) stream_get_contents(STDIN), true);
 
-/** @var array{autoloadPath: string, sapiUrl: string, sapiToken: string, bucketId: string, tableName: string, columns: string[], primaryKey: string[], isTyped: bool, displayName?: string, tableDefinition?: array<string, mixed>} $raw */
+/** @var array{autoloadPath: string, sapiUrl: string, sapiToken: string, runId: string|null, bucketId: string, tableName: string, columns: string[], primaryKey: string[], isTyped: bool, displayName?: string, tableDefinition?: array<string, mixed>} $raw */
 require $raw['autoloadPath'];
 
 use Keboola\Csv\CsvFile;
@@ -13,6 +13,9 @@ use Keboola\StorageApi\ClientException;
 use Keboola\Temp\Temp;
 
 $client = new Client(['url' => $raw['sapiUrl'], 'token' => $raw['sapiToken']]);
+if ($raw['runId'] !== null) {
+    $client->setRunId($raw['runId']);
+}
 
 try {
     if ($raw['isTyped']) {

--- a/src/worker-create-table.php
+++ b/src/worker-create-table.php
@@ -9,7 +9,7 @@ use Keboola\Temp\Temp;
 
 $raw = json_decode((string) stream_get_contents(STDIN), true);
 
-/** @var array{autoloadPath: string, sapiUrl: string, sapiToken: string, runId: string|null, bucketId: string, tableName: string, columns: string[], primaryKey: string[], isTyped: bool, displayName?: string, tableDefinition?: array<string, mixed>} $raw */
+/** @var array{autoloadPath: string, sapiUrl: string, sapiToken: string, runId: string|null, bucketId: string, tableName: string, columns: string[], primaryKey: string[], isTyped: bool, displayName: string, tableDefinition?: array<string, mixed>} $raw */
 require $raw['autoloadPath'];
 
 $client = new Client(['url' => $raw['sapiUrl'], 'token' => $raw['sapiToken']]);
@@ -33,9 +33,7 @@ try {
         );
     }
 
-    if (isset($raw['displayName'])) {
-        $client->updateTable($tableId, ['displayName' => $raw['displayName']]);
-    }
+    $client->updateTable($tableId, ['displayName' => $raw['displayName']]);
 
     echo json_encode(['tableId' => $tableId, 'error' => null]);
     exit(0);

--- a/src/worker-create-table.php
+++ b/src/worker-create-table.php
@@ -2,36 +2,36 @@
 
 declare(strict_types=1);
 
+$raw = json_decode((string) stream_get_contents(STDIN), true);
+
+/** @var array{autoloadPath: string, sapiUrl: string, sapiToken: string, bucketId: string, tableName: string, columns: string[], primaryKey: string[], isTyped: bool, displayName?: string, tableDefinition?: array<string, mixed>} $raw */
+require $raw['autoloadPath'];
+
 use Keboola\Csv\CsvFile;
 use Keboola\StorageApi\Client;
 use Keboola\StorageApi\ClientException;
 use Keboola\Temp\Temp;
 
-require __DIR__ . '/../vendor/autoload.php';
-
-/** @var array{sapiUrl: string, sapiToken: string, bucketId: string, tableName: string, columns: string[], primaryKey: string[], isTyped: bool, displayName?: string, tableDefinition?: array<string, mixed>} $input */
-$input = json_decode((string) stream_get_contents(STDIN), true);
-
-$client = new Client(['url' => $input['sapiUrl'], 'token' => $input['sapiToken']]);
+$client = new Client(['url' => $raw['sapiUrl'], 'token' => $raw['sapiToken']]);
 
 try {
-    if ($input['isTyped']) {
-        $tableId = $client->createTableDefinition($input['bucketId'], $input['tableDefinition'] ?? []);
+    if ($raw['isTyped']) {
+        $tableId = $client->createTableDefinition($raw['bucketId'], $raw['tableDefinition'] ?? []);
     } else {
         $tmp = new Temp();
-        $headerFile = new CsvFile($tmp->createFile(sprintf('%s.header.csv', $input['tableName']))->getPathname());
-        $headerFile->writeRow($input['columns']);
+        $headerFile = new CsvFile($tmp->createFile(sprintf('%s.header.csv', $raw['tableName']))->getPathname());
+        $headerFile->writeRow($raw['columns']);
 
         $tableId = $client->createTableAsync(
-            $input['bucketId'],
-            $input['tableName'],
+            $raw['bucketId'],
+            $raw['tableName'],
             $headerFile,
-            ['primaryKey' => implode(',', $input['primaryKey'])],
+            ['primaryKey' => implode(',', $raw['primaryKey'])],
         );
     }
 
-    if (isset($input['displayName'])) {
-        $client->updateTable($tableId, ['displayName' => $input['displayName']]);
+    if (isset($raw['displayName'])) {
+        $client->updateTable($tableId, ['displayName' => $raw['displayName']]);
     }
 
     echo json_encode(['tableId' => $tableId, 'error' => null]);

--- a/src/worker-create-table.php
+++ b/src/worker-create-table.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use Keboola\Csv\CsvFile;
+use Keboola\StorageApi\Client;
+use Keboola\StorageApi\ClientException;
+use Keboola\Temp\Temp;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+/** @var array{sapiUrl: string, sapiToken: string, bucketId: string, tableName: string, columns: string[], primaryKey: string[], isTyped: bool, displayName?: string, tableDefinition?: array<string, mixed>} $input */
+$input = json_decode((string) stream_get_contents(STDIN), true);
+
+$client = new Client(['url' => $input['sapiUrl'], 'token' => $input['sapiToken']]);
+
+try {
+    if ($input['isTyped']) {
+        $tableId = $client->createTableDefinition($input['bucketId'], $input['tableDefinition'] ?? []);
+    } else {
+        $tmp = new Temp();
+        $headerFile = new CsvFile($tmp->createFile(sprintf('%s.header.csv', $input['tableName']))->getPathname());
+        $headerFile->writeRow($input['columns']);
+
+        $tableId = $client->createTableAsync(
+            $input['bucketId'],
+            $input['tableName'],
+            $headerFile,
+            ['primaryKey' => implode(',', $input['primaryKey'])],
+        );
+    }
+
+    if (isset($input['displayName'])) {
+        $client->updateTable($tableId, ['displayName' => $input['displayName']]);
+    }
+
+    echo json_encode(['tableId' => $tableId, 'error' => null]);
+    exit(0);
+} catch (ClientException $e) {
+    $isNullablePkError = $e->getCode() === 400
+        && (bool) preg_match('/Primary keys columns must be set nullable false/', $e->getMessage());
+
+    echo json_encode([
+        'tableId' => null,
+        'error' => $e->getMessage(),
+        'code' => $e->getCode(),
+        'isNullablePkError' => $isNullablePkError,
+        'isClientException' => true,
+    ]);
+    exit(1);
+} catch (Throwable $e) {
+    echo json_encode([
+        'tableId' => null,
+        'error' => $e->getMessage(),
+        'code' => 0,
+        'isNullablePkError' => false,
+        'isClientException' => false,
+    ]);
+    exit(1);
+}

--- a/src/worker-create-table.php
+++ b/src/worker-create-table.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-$raw = json_decode((string) stream_get_contents(STDIN), true);
-
-/** @var array{autoloadPath: string, sapiUrl: string, sapiToken: string, runId: string|null, bucketId: string, tableName: string, columns: string[], primaryKey: string[], isTyped: bool, displayName?: string, tableDefinition?: array<string, mixed>} $raw */
-require $raw['autoloadPath'];
-
 use Keboola\Csv\CsvFile;
 use Keboola\StorageApi\Client;
 use Keboola\StorageApi\ClientException;
 use Keboola\Temp\Temp;
+
+$raw = json_decode((string) stream_get_contents(STDIN), true);
+
+/** @var array{autoloadPath: string, sapiUrl: string, sapiToken: string, runId: string|null, bucketId: string, tableName: string, columns: string[], primaryKey: string[], isTyped: bool, displayName?: string, tableDefinition?: array<string, mixed>} $raw */
+require $raw['autoloadPath'];
 
 $client = new Client(['url' => $raw['sapiUrl'], 'token' => $raw['sapiToken']]);
 if ($raw['runId'] !== null) {

--- a/tests/CommonRestoreTest.php
+++ b/tests/CommonRestoreTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Keboola\ProjectRestore\Tests;
 
+use InvalidArgumentException;
 use Keboola\ProjectRestore\AbsRestore;
 use Keboola\StorageApi\Client;
 use Keboola\StorageApi\ClientException;
@@ -653,7 +654,7 @@ class CommonRestoreTest extends TestCase
         /** @var BlobRestProxy $absClientMock */
         $restore = new AbsRestore($storageClientMock, $absClientMock, 'test-container', new NullLogger());
 
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $restore->restoreTables(0);
     }
 

--- a/tests/CommonRestoreTest.php
+++ b/tests/CommonRestoreTest.php
@@ -634,6 +634,63 @@ class CommonRestoreTest extends TestCase
         );
     }
 
+    public function testInterleaveByBucket(): void
+    {
+        // 3 buckets: A has 3 tables, B has 2, C has 1
+        // Expected round-robin order: A1, B1, C1, A2, B2, A3
+        $tableJson = json_encode([
+            ['id' => 'in.c-a.t1', 'name' => 't1', 'isAlias' => false, 'isTyped' => false,
+                'primaryKey' => [], 'columns' => ['id'], 'bucket' => ['id' => 'in.c-a', 'backend' => 'snowflake']],
+            ['id' => 'in.c-a.t2', 'name' => 't2', 'isAlias' => false, 'isTyped' => false,
+                'primaryKey' => [], 'columns' => ['id'], 'bucket' => ['id' => 'in.c-a', 'backend' => 'snowflake']],
+            ['id' => 'in.c-a.t3', 'name' => 't3', 'isAlias' => false, 'isTyped' => false,
+                'primaryKey' => [], 'columns' => ['id'], 'bucket' => ['id' => 'in.c-a', 'backend' => 'snowflake']],
+            ['id' => 'in.c-b.t1', 'name' => 't1', 'isAlias' => false, 'isTyped' => false,
+                'primaryKey' => [], 'columns' => ['id'], 'bucket' => ['id' => 'in.c-b', 'backend' => 'snowflake']],
+            ['id' => 'in.c-b.t2', 'name' => 't2', 'isAlias' => false, 'isTyped' => false,
+                'primaryKey' => [], 'columns' => ['id'], 'bucket' => ['id' => 'in.c-b', 'backend' => 'snowflake']],
+            ['id' => 'in.c-c.t1', 'name' => 't1', 'isAlias' => false, 'isTyped' => false,
+                'primaryKey' => [], 'columns' => ['id'], 'bucket' => ['id' => 'in.c-c', 'backend' => 'snowflake']],
+        ]);
+
+        $absClientMock = $this->createMock(BlobRestProxy::class);
+        $absClientMock->method('getBlob')->willReturn($this->createBlobResultMock((string) $tableJson));
+        $listBlobsResult = $this->createMock(ListBlobsResult::class);
+        $listBlobsResult->method('getBlobs')->willReturn([]);
+        $absClientMock->method('listBlobs')->willReturn($listBlobsResult);
+
+        $storageClientMock = $this->createMock(Client::class);
+        $storageClientMock->method('apiGet')->with('dev-branches/')->willReturn([['id' => 1, 'isDefault' => true]]);
+        $storageClientMock->method('getApiUrl')->willReturn('https://connection');
+        $storageClientMock->method('getTokenString')->willReturn('token');
+        $storageClientMock->method('verifyToken')->willReturn(
+            ['id' => '1', 'description' => '', 'owner' => ['id' => 1, 'name' => 'test']],
+        );
+        $storageClientMock->token = 'test-token';
+        $storageClientMock->method('listBuckets')->willReturn([
+            ['id' => 'in.c-a', 'backend' => 'snowflake'],
+            ['id' => 'in.c-b', 'backend' => 'snowflake'],
+            ['id' => 'in.c-c', 'backend' => 'snowflake'],
+        ]);
+
+        /** @var Client $storageClientMock */
+        /** @var BlobRestProxy $absClientMock */
+        $restore = new AbsRestore($storageClientMock, $absClientMock, 'test-container', new NullLogger());
+
+        $capturedBuckets = [];
+        $restore->setWorkerProcessFactory(function (array $input) use (&$capturedBuckets): Process {
+            $capturedBuckets[] = $input['bucketId'];
+            return $this->createSuccessProcessMock($input['bucketId'] . '.' . $input['tableName']);
+        });
+
+        $restore->restoreTables();
+
+        self::assertSame(
+            ['in.c-a', 'in.c-b', 'in.c-c', 'in.c-a', 'in.c-b', 'in.c-a'],
+            $capturedBuckets,
+        );
+    }
+
     private function createSuccessProcessMock(string $tableId): Process
     {
         $process = $this->createMock(Process::class);

--- a/tests/CommonRestoreTest.php
+++ b/tests/CommonRestoreTest.php
@@ -634,6 +634,29 @@ class CommonRestoreTest extends TestCase
         );
     }
 
+    public function testRestoreTablesThrowsOnInvalidParallelism(): void
+    {
+        $absClientMock = $this->createMock(BlobRestProxy::class);
+        $absClientMock->method('getBlob')->willReturn($this->createBlobResultMock('[]'));
+
+        $storageClientMock = $this->createMock(Client::class);
+        $storageClientMock->method('apiGet')->with('dev-branches/')->willReturn([['id' => 1, 'isDefault' => true]]);
+        $storageClientMock->method('getApiUrl')->willReturn('https://connection');
+        $storageClientMock->method('getTokenString')->willReturn('token');
+        $storageClientMock->method('verifyToken')->willReturn(
+            ['id' => '1', 'description' => '', 'owner' => ['id' => 1, 'name' => 'test']],
+        );
+        $storageClientMock->token = 'test-token';
+        $storageClientMock->method('listBuckets')->willReturn([]);
+
+        /** @var Client $storageClientMock */
+        /** @var BlobRestProxy $absClientMock */
+        $restore = new AbsRestore($storageClientMock, $absClientMock, 'test-container', new NullLogger());
+
+        $this->expectException(\InvalidArgumentException::class);
+        $restore->restoreTables(0);
+    }
+
     public function testInterleaveByBucket(): void
     {
         // 3 buckets: A has 3 tables, B has 2, C has 1

--- a/tests/CommonRestoreTest.php
+++ b/tests/CommonRestoreTest.php
@@ -18,6 +18,7 @@ use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\Process\Process;
 use Throwable;
 
 class CommonRestoreTest extends TestCase
@@ -101,10 +102,6 @@ class CommonRestoreTest extends TestCase
                 ],
             ]);
 
-        $storageClientMock
-            ->method('createTableDefinition')
-            ->willThrowException($clientException);
-
         /**
          * @var Client $storageClientMock
          * @var BlobRestProxy $absClientMock
@@ -114,6 +111,19 @@ class CommonRestoreTest extends TestCase
             $absClientMock,
             'test-container',
             new NullLogger(),
+        );
+
+        $isNullablePkError = $clientException instanceof ClientException
+            && $clientException->getCode() === 400
+            && (bool) preg_match('/Primary keys columns must be set nullable false/', $clientException->getMessage());
+
+        $restore->setWorkerProcessFactory(
+            fn(array $input): Process => $this->createErrorProcessMock(
+                $clientException->getMessage(),
+                $clientException instanceof ClientException ? $clientException->getCode() : 0,
+                $isNullablePkError,
+                $clientException instanceof ClientException,
+            ),
         );
 
         $this->expectException($expectedExceptionClass);
@@ -331,8 +341,6 @@ class CommonRestoreTest extends TestCase
         $storageClientMock->method('listBuckets')->willReturn([
             ['id' => 'in.c-bucket', 'backend' => 'bigquery'],
         ]);
-        $storageClientMock->expects($this->never())->method('createTableDefinition');
-
         /** @var Client $storageClientMock */
         /** @var BlobRestProxy $absClientMock */
         $restore = new AbsRestore($storageClientMock, $absClientMock, 'test-container', new NullLogger());
@@ -384,12 +392,23 @@ class CommonRestoreTest extends TestCase
         $storageClientMock->method('listBuckets')->willReturn([
             ['id' => 'in.c-bucket', 'backend' => 'bigquery'],
         ]);
-        $storageClientMock->expects($this->once())->method('createTableDefinition')->willReturn('in.c-bucket.amounts');
-
         /** @var Client $storageClientMock */
         /** @var BlobRestProxy $absClientMock */
         $restore = new AbsRestore($storageClientMock, $absClientMock, 'test-container', new NullLogger());
+
+        /** @var array<string, mixed>|null $capturedWorkerInput */
+        $capturedWorkerInput = null;
+        $restore->setWorkerProcessFactory(function (array $input) use (&$capturedWorkerInput): Process {
+            $capturedWorkerInput = $input;
+            return $this->createSuccessProcessMock('in.c-bucket.amounts');
+        });
+
         $restore->restoreTables();
+
+        self::assertNotNull($capturedWorkerInput);
+        self::assertTrue($capturedWorkerInput['isTyped']);
+        // table definition should have been built (cross-backend Snowflake→BigQuery)
+        self::assertArrayHasKey('tableDefinition', $capturedWorkerInput);
     }
 
     public function testForcePrimaryKeyNotNullOverridesNullable(): void
@@ -442,28 +461,35 @@ class CommonRestoreTest extends TestCase
             ['id' => 'in.c-bucket', 'backend' => 'snowflake'],
         ]);
 
-        $storageClientMock
-            ->expects($this->once())
-            ->method('createTableDefinition')
-            ->with(
-                'in.c-bucket',
-                $this->callback(function (array $data): bool {
-                    $idColumn = current(array_filter($data['columns'], fn($c) => $c['name'] === 'Id'));
-                    $nameColumn = current(array_filter($data['columns'], fn($c) => $c['name'] === 'Name'));
-                    // PK column must be forced to NOT NULL
-                    self::assertFalse($idColumn['definition']['nullable']);
-                    // non-PK column must remain nullable
-                    self::assertTrue($nameColumn['definition']['nullable']);
-                    return true;
-                }),
-            )
-            ->willReturn('in.c-bucket.Account');
-
         /** @var Client $storageClientMock */
         /** @var BlobRestProxy $absClientMock */
         $restore = new AbsRestore($storageClientMock, $absClientMock, 'test-container', $logger);
         $restore->setForcePrimaryKeyNotNull(true);
+
+        /** @var array<string, mixed>|null $capturedWorkerInput */
+        $capturedWorkerInput = null;
+        $restore->setWorkerProcessFactory(function (array $input) use (&$capturedWorkerInput): Process {
+            $capturedWorkerInput = $input;
+            return $this->createSuccessProcessMock('in.c-bucket.Account');
+        });
+
         $restore->restoreTables();
+
+        self::assertNotNull($capturedWorkerInput);
+        /** @var array{columns: array<int, array{name: string, definition: array{nullable: bool}}>} $tableDefinition */
+        $tableDefinition = $capturedWorkerInput['tableDefinition'];
+        $idColumnMatches = array_values(
+            array_filter($tableDefinition['columns'], fn(array $c): bool => $c['name'] === 'Id'),
+        );
+        $nameColumnMatches = array_values(
+            array_filter($tableDefinition['columns'], fn(array $c): bool => $c['name'] === 'Name'),
+        );
+        self::assertCount(1, $idColumnMatches);
+        self::assertCount(1, $nameColumnMatches);
+        // PK column must be forced to NOT NULL
+        self::assertFalse($idColumnMatches[0]['definition']['nullable']);
+        // non-PK column must remain nullable
+        self::assertTrue($nameColumnMatches[0]['definition']['nullable']);
 
         $messages = array_map(fn($r) => $r['message'], $logsHandler->getRecords());
         self::assertContains(
@@ -516,12 +542,13 @@ class CommonRestoreTest extends TestCase
         $storageClientMock->method('listBuckets')->willReturn([
             ['id' => 'in.c-bucket', 'backend' => 'snowflake'],
         ]);
-        $storageClientMock->method('createTableDefinition')->willReturn('in.c-bucket.Account');
-
         /** @var Client $storageClientMock */
         /** @var BlobRestProxy $absClientMock */
         $restore = new AbsRestore($storageClientMock, $absClientMock, 'test-container', $logger);
         $restore->setForcePrimaryKeyNotNull(true);
+        $restore->setWorkerProcessFactory(
+            fn(array $input): Process => $this->createSuccessProcessMock('in.c-bucket.Account'),
+        );
         $restore->restoreTables();
 
         $infoMessages = array_map(
@@ -588,12 +615,13 @@ class CommonRestoreTest extends TestCase
         $storageClientMock->method('listBuckets')->willReturn([
             ['id' => 'in.c-bucket', 'backend' => 'snowflake'],
         ]);
-        $storageClientMock->method('createTableDefinition')->willReturn('in.c-bucket.Account');
-
         /** @var Client $storageClientMock */
         /** @var BlobRestProxy $absClientMock */
         $restore = new AbsRestore($storageClientMock, $absClientMock, 'test-container', $logger);
         // setForcePrimaryKeyNotNull NOT called — default behaviour
+        $restore->setWorkerProcessFactory(
+            fn(array $input): Process => $this->createSuccessProcessMock('in.c-bucket.Account'),
+        );
         $restore->restoreTables();
 
         $warnMessages = array_map(
@@ -604,6 +632,41 @@ class CommonRestoreTest extends TestCase
             'Table "Account" cannot be restored because the primary key column "Id" is nullable.',
             $warnMessages,
         );
+    }
+
+    private function createSuccessProcessMock(string $tableId): Process
+    {
+        $process = $this->createMock(Process::class);
+        $process->method('start')->willReturn(null);
+        $process->method('isRunning')->willReturn(false);
+        $process->method('getExitCode')->willReturn(0);
+        $process->method('getOutput')->willReturn((string) json_encode([
+            'tableId' => $tableId,
+            'error' => null,
+        ]));
+        /** @var Process $process */
+        return $process;
+    }
+
+    private function createErrorProcessMock(
+        string $errorMessage,
+        int $code,
+        bool $isNullablePkError,
+        bool $isClientException,
+    ): Process {
+        $process = $this->createMock(Process::class);
+        $process->method('start')->willReturn(null);
+        $process->method('isRunning')->willReturn(false);
+        $process->method('getExitCode')->willReturn(1);
+        $process->method('getOutput')->willReturn((string) json_encode([
+            'tableId' => null,
+            'error' => $errorMessage,
+            'code' => $code,
+            'isNullablePkError' => $isNullablePkError,
+            'isClientException' => $isClientException,
+        ]));
+        /** @var Process $process */
+        return $process;
     }
 
     private function createBlobResultMock(string $content): GetBlobResult


### PR DESCRIPTION
## Summary

- Table creation (`createTable` / `createTableDefinition`) is now parallelized using `symfony/process` worker processes (default concurrency: 5)
- Metadata updates and data uploads remain sequential
- Typed table definitions are pre-computed in the main process via extracted `buildTypedTableDefinition()` — no I/O in workers
- `setParallelism(int)` and `setWorkerProcessFactory(Closure)` added to `Restore` for configuration and testability

## Test plan

- [x] `docker compose run --rm tests composer phpcs`
- [x] `docker compose run --rm tests composer phpstan`
- [x] `docker compose run --rm tests composer tests-abs`
- [x] `docker compose run --rm tests composer tests-s3`
- [x] `docker compose run --rm tests composer tests-gcs`