### PR TITLE
[AJDA-2577] Add architectural documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,95 @@
+# php-kbc-project-restore – AI Development Context
+
+## What this repository does
+
+Low-level PHP library for restoring a Keboola project from a backup in cloud storage. Used by `app-project-restore` as its restore engine.
+
+## Documentation
+
+- **`docs/overview.md`** – public methods, worker-create-table.php, what is skipped, helper classes
+- **`docs/how-it-works.md`** – step-by-step restore flow (3 phases of restoreTables, interleaveByBucket, getDataFromStorage per backend)
+
+## Required environment variables
+
+Before running tests, verify that these variables are present in `.env` (or exported in the shell). If missing, ask for them explicitly.
+
+**For AWS S3 tests:**
+
+| Variable | Description |
+|---|---|
+| `TEST_STORAGE_API_URL` | Keboola project URL (destination) |
+| `TEST_STORAGE_API_TOKEN` | Project storage token (destination) |
+| `TEST_AWS_ACCESS_KEY_ID` | AWS Access Key ID |
+| `TEST_AWS_SECRET_ACCESS_KEY` | AWS Secret Access Key |
+| `TEST_AWS_REGION` | AWS region (e.g. `us-east-1`) |
+| `TEST_AWS_S3_BUCKET` | S3 bucket name containing the backup |
+
+**For Azure ABS tests:**
+
+| Variable | Description |
+|---|---|
+| `TEST_AZURE_ACCOUNT_NAME` | Azure storage account name |
+| `TEST_AZURE_ACCOUNT_KEY` | Azure storage key |
+| `TEST_AZURE_CONTAINER_NAME` | Azure Blob Storage container name containing the backup |
+
+**For GCS tests:**
+
+| Variable | Description |
+|---|---|
+| `TEST_GCP_SERVICE_ACCOUNT` | JSON service account key (full JSON as string) |
+| `TEST_GCP_BUCKET` | GCS bucket name containing the backup |
+
+> Check that the `.env` file exists in the repo root. If not, create it based on the list above.
+
+## Development commands
+
+Service name in `docker-compose.yml` is `tests`. Note: `composer tests` runs **only** `tests-abs` and `tests-s3` – GCS tests are run separately via `tests-gcs`.
+
+```bash
+docker compose run --rm tests composer phpcs
+docker compose run --rm tests composer phpstan
+docker compose run --rm tests composer tests              # tests-abs + tests-s3 (WITHOUT GCS)
+docker compose run --rm tests composer tests-abs          # Azure Blob Storage
+docker compose run --rm tests composer tests-s3           # AWS S3
+docker compose run --rm tests composer tests-gcs          # Google Cloud Storage
+docker compose run --rm tests composer tests-cross-backends
+docker compose run --rm tests composer tests-phpunit      # direct phpunit call (without data preparation)
+docker compose run --rm tests composer prepare-test-data  # test data preparation
+docker compose run --rm tests composer build              # phplint + phpcs + phpstan + tests
+docker compose run --rm tests composer ci-except-tests    # build without running tests
+```
+
+## Key files
+
+| File | Purpose |
+|---|---|
+| `src/Restore.php` | Abstract class – all restore logic |
+| `src/S3Restore.php` | AWS S3 implementation |
+| `src/AbsRestore.php` | Azure Blob Storage implementation |
+| `src/GcsRestore.php` | Google Cloud Storage implementation |
+| `src/worker-create-table.php` | Child process for parallel table creation |
+| `src/StorageApi/Token.php` | Token permission validation |
+| `src/StorageApi/BucketInfo.php` | Working with bucket information from backup |
+| `src/StorageApi/ConfigurationCorrector.php` | Configuration correction after migration (component ID translations) |
+| `src/StorageApi/StackSpecificComponentIdTranslator.php` | Component ID translation between stacks |
+
+## worker-create-table.php
+
+Child process launched via `symfony/process`. Accepts JSON via STDIN, creates one table in Storage API (typed or untyped), returns JSON with result or error.
+
+Special error flags: `isNullablePkError` (PK column is nullable – resolved by `forcePrimaryKeyNotNull`), `isClientException`.
+
+## Architecture
+
+Abstract class `Restore` + concrete implementations for each backend. Parallel table creation via worker scripts.
+
+## Coding standards
+
+- PHP 8.x with strict types
+- PHPStan level max
+- Keboola coding standard (PSR-12)
+
+## Related repositories
+
+- Used in: `app-project-restore`
+- Paired with: `php-kbc-project-backup`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ docker compose run --rm tests composer tests-gcs          # Google Cloud Storage
 docker compose run --rm tests composer tests-cross-backends
 docker compose run --rm tests composer tests-phpunit      # direct phpunit call (without data preparation)
 docker compose run --rm tests composer prepare-test-data  # test data preparation
-docker compose run --rm tests composer build              # phplint + phpcs + phpstan + tests
+docker compose run --rm tests composer build              # phplint + phpcs + phpstan
 docker compose run --rm tests composer ci-except-tests    # build without running tests
 ```
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -3,7 +3,10 @@
 ## Initializing the Restore class
 
 ```php
-new S3Restore($sapiClient, $logger)  // or AbsRestore / GcsRestore
+$restore = new S3Restore($sapiClient, $s3Client, $bucket, $path, $logger);
+// or, for other backends:
+// $restore = new AbsRestore($sapiClient, $absClient, $container, $logger);
+// $restore = new GcsRestore($sapiClient, $listFiles, $logger);
 ```
 
 `Restore::__construct()` constructor:
@@ -151,7 +154,7 @@ Child process. Receives JSON from STDIN, creates one table via SAPI, returns JSO
 **Input:**
 ```json
 {
-  "sapiUrl": "...", "sapiToken": "...", "runId": "...",
+  "autoloadPath": "...", "sapiUrl": "...", "sapiToken": "...", "runId": "...",
   "bucketId": "in.c-bucket", "tableName": "my_table",
   "displayName": "My Table", "columns": [...],
   "primaryKey": [...], "isTyped": true,
@@ -159,13 +162,22 @@ Child process. Receives JSON from STDIN, creates one table via SAPI, returns JSO
 }
 ```
 
-**Output:**
+**Output (success):**
 ```json
 {
   "tableId": "in.c-bucket.my_table",
-  "error": null, "code": null,
+  "error": null
+}
+```
+
+**Output (error):**
+```json
+{
+  "tableId": null,
+  "error": "...",
+  "code": 400,
   "isNullablePkError": false,
-  "isClientException": false
+  "isClientException": true
 }
 ```
 
@@ -211,7 +223,7 @@ Abstract method `getDataFromStorage(string $name)` is implemented in each backen
 |---------|-------------|
 | `S3Restore` | `S3Client::getObject(Bucket, Key)` |
 | `AbsRestore` | `BlobRestProxy::getBlob(container, name)` |
-| `GcsRestore` | `StorageObject::downloadAsString()` |
+| `GcsRestore` | Looks up the file in the precomputed `listFiles` tree/URLs, copies it to a temporary local file, then reads that file |
 
 Returns file content as string or stream.
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -1,0 +1,223 @@
+# php-kbc-project-restore – how the restore works
+
+## Initializing the Restore class
+
+```php
+new S3Restore($sapiClient, $logger)  // or AbsRestore / GcsRestore
+```
+
+`Restore::__construct()` constructor:
+1. Stores `sapiClient` and initializes `Token` (permission validation wrapper)
+2. Fetches branch list (`DevBranches::listBranches()`)
+3. Finds the default branch (`isDefault === true`)
+4. Creates `BranchAwareClient` for operations on the default branch
+
+## Complete restore flow
+
+```
+restoreProjectMetadata()
+  └─ getDataFromStorage('defaultBranchMetadata.json')
+  └─ DevBranchesMetadata::addBranchMetadata()
+
+restoreBuckets(checkBackend)
+  └─ getDataFromStorage('buckets.json')
+  └─ forEach bucket: createBucket() + postBucketMetadata()
+
+restoreConfigs(skipComponents)
+  └─ getDataFromStorage('configurations.json')
+  └─ forEach component (excluding skipComponents):
+       forEach config: addConfiguration() + updateConfiguration()
+       forEach row: addConfigurationRow() + updateConfigurationRow()
+       addConfigurationMetadata()
+
+restoreTables(parallelism)
+  ├─ Phase 1: prepare workItems from 'tables.json'
+  ├─ Phase 2: createTablesParallel (worker-create-table.php)
+  └─ Phase 3: sequential data upload + column metadata
+
+restoreTableAliases()
+  └─ from 'tables.json', only where isAlias === true
+  └─ createAliasTable()
+
+restoreTriggers()
+  └─ getDataFromStorage('triggers.json') → createTrigger()
+
+restoreNotifications()
+  └─ getDataFromStorage('notifications.json') → SubscriptionClient::createSubscription()
+
+restorePermanentFiles()
+  └─ getDataFromStorage('permanentFiles.json') → forEach: uploadFile()
+```
+
+## restoreConfigs – detail
+
+```
+getDataFromStorage('configurations.json')  →  list of components with configurations
+
+forEach component:
+  if componentId in skipComponents: skip + warn
+
+  if componentId not in indexAction(): skip + warn
+
+  forEach configuration:
+    getDataFromStorage('configurations/<componentId>/<configId>.json')
+
+    addConfiguration(id, name, description)
+      if keboola.orchestrator: isDisabled = true
+
+    ConfigurationCorrector::correct()
+      → translates stack-dependent component IDs (StackSpecificComponentIdTranslator)
+    updateConfiguration(configuration, state)
+
+    forEach row:
+      addConfigurationRow(rowId)
+      updateConfigurationRow(configuration, state, isDisabled)
+
+    if rowsSortOrder:
+      updateConfiguration(rowsSortOrder)
+
+    if .json.metadata exists:
+      addConfigurationMetadata()
+```
+
+### Why orchestrator gets isDisabled = true
+
+`keboola.orchestrator` configurations are restored structurally (flow, triggers, steps are preserved), but automatically set to `isDisabled: true`. Otherwise, orchestrations could start running immediately after restore, before data and configurations in the destination project are verified. Users must manually re-enable them.
+
+## restoreTables – 3 phases
+
+### Phase 1: Prepare work items
+
+```
+getDataFromStorage('tables.json')  →  list of all tables
+
+forEach table:
+  skip: isAlias === true
+  skip: bucket was not restored
+  checkTableRestorable(tableInfo)  – compatibility check
+
+  workerInput = {
+    sapiUrl, sapiToken, runId,
+    bucketId, tableName, displayName,
+    columns, primaryKey, isTyped,
+    tableDefinition (for typed tables)
+  }
+```
+
+### buildTypedTableDefinition
+
+For typed tables (Snowflake native typing, BigQuery), `tableDefinition` is assembled with columns and their data types. Backend is read from `restoredBuckets` (column map `bucketId → backend`).
+
+Special case BigQuery: Snowflake `NUMERIC` with `scale ≤ 9` maps to BigQuery `NUMERIC` instead of `BIGNUMERIC`.
+
+### Phase 2: Parallel table creation
+
+```
+interleaveByBucket(workItems)
+  → interleaves tables across buckets
+  → [bucket_A_table_1, bucket_B_table_1, bucket_C_table_1, bucket_A_table_2, ...]
+  → reason: Snowflake locks schema metadata, multiple tables in the same bucket would wait
+
+createTablesParallel(workItems, parallelism):
+  pendingItems = workItems
+  runningProcesses = {}
+
+  while pendingItems or runningProcesses:
+    while free slots and pendingItems:
+      process = createWorkerProcess(workerInput)
+      process.start()
+      runningProcesses[tableId] = process
+
+    forEach completed process:
+      output = json_decode(process.getOutput())
+
+      if error:
+        isNullablePkError → StorageApiException (PK on nullable column)
+        isClientException → ClientException (4xx)
+        else              → RuntimeException
+
+      else:
+        createdTableIds[originalTableId] = output.tableId
+
+    usleep(100ms)  ← polling interval
+
+  return createdTableIds
+```
+
+### Worker: worker-create-table.php
+
+Child process. Receives JSON from STDIN, creates one table via SAPI, returns JSON on STDOUT.
+
+**Input:**
+```json
+{
+  "sapiUrl": "...", "sapiToken": "...", "runId": "...",
+  "bucketId": "in.c-bucket", "tableName": "my_table",
+  "displayName": "My Table", "columns": [...],
+  "primaryKey": [...], "isTyped": true,
+  "tableDefinition": {...}
+}
+```
+
+**Output:**
+```json
+{
+  "tableId": "in.c-bucket.my_table",
+  "error": null, "code": null,
+  "isNullablePkError": false,
+  "isClientException": false
+}
+```
+
+### Phase 3: Data and column metadata upload
+
+```
+forEach createdTable:
+  restoreTableColumnsMetadata(tableInfo, tableId)
+    → postColumnMetadata() for each column with metadata
+
+  slices = listTableFiles(tableId)
+    → iterates storage, finds table files
+
+  if no files: skip (empty table)
+
+  if 1 file and not .part_0.csv.gz (non-sliced):
+    copyFileFromStorage(slice, localPath)
+    uploadFile() → writeTableAsyncDirect(dataFileId)
+
+  if sliced:
+    forEach slice:
+      copyFileFromStorage(slice, localPath)
+    uploadSlicedFile(federationToken=true) → writeTableAsyncDirect(dataFileId, columns)
+```
+
+## restoreTableAliases – why after tables
+
+An alias table is defined by a reference to the source table (`sourceTable.id`). If the alias were created before the source table exists, SAPI would return an error. Therefore `restoreTableAliases()` is always called after `restoreTables()`.
+
+```
+forEach table where isAlias === true:
+  if not tableExists(sourceTableId): skip + warn
+  if bucket does not exist: skip + warn
+  createAliasTable(bucketId, sourceTableId, name, aliasFilter?, aliasColumns?)
+  restoreTableColumnsMetadata()
+```
+
+## getDataFromStorage – implementation per backend
+
+Abstract method `getDataFromStorage(string $name)` is implemented in each backend:
+
+| Backend | Implementation |
+|---------|-------------|
+| `S3Restore` | `S3Client::getObject(Bucket, Key)` |
+| `AbsRestore` | `BlobRestProxy::getBlob(container, name)` |
+| `GcsRestore` | `StorageObject::downloadAsString()` |
+
+Returns file content as string or stream.
+
+## Dry-run mode
+
+`setDryRunMode(true)`:
+- All storage read operations proceed normally
+- No SAPI write operations are executed (`addConfiguration`, `createBucket`, `uploadFile`, ...)
+- Each skipped operation is logged as `[dry-run] ...`

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,122 @@
+# php-kbc-project-restore – overview
+
+## What the library does
+
+Low-level PHP library for restoring a Keboola project from a backup in cloud storage. Contains no Keboola-specific boilerplate – it is pure restore logic.
+
+Used by `app-project-restore` as its restore engine.
+
+## Architecture
+
+Abstract class `Restore` contains all logic. Concrete storage backends extend it:
+
+```
+Restore (abstract)
+  ├─ S3Restore      – AWS S3
+  ├─ AbsRestore     – Azure Blob Storage
+  └─ GcsRestore     – Google Cloud Storage
+```
+
+A worker script exists for parallel table creation:
+
+```
+worker-create-table.php  – child process (symfony/process), one per table
+```
+
+## Public methods
+
+| Method | What it does |
+|---|---|
+| `restoreProjectMetadata()` | Restores default branch metadata |
+| `restoreBuckets(bool $checkBackend)` | Creates buckets; `checkBackend=false` ignores backend from backup |
+| `restoreConfigs(array $skipComponents)` | Restores component configurations (except `skipComponents`) |
+| `restoreTables(int $parallelism)` | Creates tables in parallel via worker scripts |
+| `restoreTableAliases()` | Restores alias tables (call after `restoreTables`) |
+| `restoreTriggers()` | Restores triggers |
+| `restoreNotifications()` | Restores notification subscriptions |
+| `restorePermanentFiles()` | Restores permanent files |
+
+## Behavior configuration
+
+| Method | Default | Description |
+|---|---|---|
+| `setDryRunMode(bool)` | `false` | Simulation – logs actions, creates nothing |
+| `setForcePrimaryKeyNotNull(bool)` | `false` | Forces NOT NULL on PK columns |
+| `setWorkerProcessFactory(Closure)` | – | Override factory for worker processes (for testing) |
+
+## worker-create-table.php
+
+Child process launched via `symfony/process`. Creates one table in Storage API.
+
+**Input (STDIN, JSON):**
+
+```json
+{
+  "autoloadPath": "...",
+  "sapiUrl": "...",
+  "sapiToken": "...",
+  "runId": "...",
+  "bucketId": "...",
+  "tableName": "...",
+  "columns": [...],
+  "primaryKey": [...],
+  "isTyped": true,
+  "displayName": "...",
+  "tableDefinition": {...}
+}
+```
+
+**Output (JSON):**
+
+```json
+{
+  "tableId": "in.c-bucket.table",
+  "error": null,
+  "code": null,
+  "isNullablePkError": false,
+  "isClientException": false
+}
+```
+
+Special flags: `isNullablePkError` – PK column is nullable, resolved by `forcePrimaryKeyNotNull`; `isClientException` – client-side error (4xx), not a server error.
+
+## Helper classes
+
+| Class | Description |
+|---|---|
+| `StorageApi/Token.php` | Token permission validation |
+| `StorageApi/BucketInfo.php` | Working with bucket information from backup |
+| `StorageApi/ConfigurationCorrector.php` | Configuration correction after migration (component ID translations) |
+| `StorageApi/StackSpecificComponentIdTranslator.php` | Component ID translation between stacks |
+
+## Key files
+
+| File | Description |
+|---|---|
+| `src/Restore.php` | Abstract class – all restore logic |
+| `src/S3Restore.php` | AWS S3 implementation |
+| `src/AbsRestore.php` | Azure Blob Storage implementation |
+| `src/GcsRestore.php` | Google Cloud Storage implementation |
+| `src/worker-create-table.php` | Child process for parallel table creation |
+| `src/StorageApi/` | Storage API utilities |
+
+## Development and testing
+
+Service name in `docker-compose.yml` is `tests`. Note: `composer tests` does not run GCS tests – those are run separately via `tests-gcs`.
+
+```bash
+docker compose run --rm tests composer phpcs
+docker compose run --rm tests composer phpstan
+docker compose run --rm tests composer tests             # tests-abs + tests-s3 (WITHOUT GCS)
+docker compose run --rm tests composer tests-abs
+docker compose run --rm tests composer tests-s3
+docker compose run --rm tests composer tests-gcs
+docker compose run --rm tests composer tests-cross-backends
+```
+
+Integration tests require live Keboola credentials (S3/ABS/GCS access + project token).
+
+## Related repositories
+
+- Used in: `app-project-restore`
+- Paired with: `php-kbc-project-backup`

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -68,13 +68,22 @@ Child process launched via `symfony/process`. Creates one table in Storage API.
 
 **Output (JSON):**
 
+**Success:**
 ```json
 {
   "tableId": "in.c-bucket.table",
-  "error": null,
-  "code": null,
+  "error": null
+}
+```
+
+**Error:**
+```json
+{
+  "tableId": null,
+  "error": "...",
+  "code": 400,
   "isNullablePkError": false,
-  "isClientException": false
+  "isClientException": true
 }
 ```
 


### PR DESCRIPTION
Add CLAUDE.md with AI development context, required environment variables, key files and development commands. Add docs/ folder with overview and how-it-works documentation covering the public Restore API, 3-phase restoreTables, interleaveByBucket rationale, worker-create-table.php details and per-backend getDataFromStorage implementations.